### PR TITLE
Add firewall rules for SQL and Key Vault + optional Private Endpoint …

### DIFF
--- a/main.bicep
+++ b/main.bicep
@@ -82,4 +82,35 @@ module diagSettingsModule './modules/diagnosticSettings.bicep' = {
   }
 }
 
+module sqlFirewall 'modules/sqlFirewallRules.bicep' = {
+  name: 'sqlFirewallRule'
+  params: {
+    sqlServerName: sqlModule.outputs.name
+    startIp: '186.182.86.0'
+    endIp: '186.182.86.255'
+  }
+}
+
+module kvFirewall 'modules/keyVaultFirewall.bicep' = {
+  name: 'keyVaultFirewallRule'
+  params: {
+    keyVaultName: keyVaultName
+    ipRange: '186.182.86.0/24'
+  }
+}
+
+// Optional Module: SQL private Endpoint
+/*
+module sqlPrivateEndpoint 'modules/privateEndpointSql.bicep' = {
+  name: 'sqlPrivateEndpoint'
+  params: {
+    location: location
+    sqlServerName: sqlModule.outputs.name
+    vnetName: 'myVnet' // Replace with your VNet name
+    subnetName: 'mySubnet' // Replace with your subnet name
+    enablePrivateEndpoint: false // Set to true if you want to enable private endpoint
+  }
+}
+
+*/
 output sqlConnectionStringFromKeyVault string = keyVaultModule.outputs.secretUri

--- a/modules/azureSql.bicep
+++ b/modules/azureSql.bicep
@@ -31,3 +31,4 @@ resource sqlDatabase 'Microsoft.Sql/servers/databases@2022-02-01-preview' = {
   }
 }
 
+output name string = sqlServer.name

--- a/modules/keyVaultFirewall.bicep
+++ b/modules/keyVaultFirewall.bicep
@@ -1,0 +1,20 @@
+param keyVaultName string
+param ipRange string = '186.182.86.0/24'
+
+resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
+  name: keyVaultName
+}
+
+resource kvFirewallRule 'Microsoft.KeyVault/vaults/firewallRules@2022-07-01' = {
+  name: 'default'
+  parent: keyVault
+  properties: {
+    defaultAction: 'Deny' // Deny all by default
+    bypass: 'AzureServices' // Allow Azure services to bypass the firewall
+    ipRules: [
+      {
+        value: ipRange // Specify the IP range to allow
+      }
+    ]
+  }
+}

--- a/modules/privateEndpointSql.bicep
+++ b/modules/privateEndpointSql.bicep
@@ -1,0 +1,32 @@
+param location string
+param sqlServerName string
+param vnetId string
+param subnetName string
+@description('Enable or not the private endpoint connection')
+param enablePrivateEndpoint bool = false
+
+resource sqlServer 'Microsoft.Sql/servers@2022-02-01' existing = {
+  name: sqlServerName
+}
+
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2023-05-01' = if (enablePrivateEndpoint) {
+  name: '${sqlServerName}-privateEndpoint'
+  location: location
+  properties: {
+    subnet: {
+      id: '${vnetId}/subnets/${subnetName}'
+    }
+    privateLinkServiceConnections: [
+      {
+        name: 'sqlServerConnection'
+        properties: {
+          privateLinkServiceId: sqlServer.id
+          groupIds: [
+            'sqlServer'
+          ]
+          requestMessage: 'Please approve the private endpoint connection.'
+        }
+      }
+    ]
+  }
+}

--- a/modules/sqlFirewallRules.bicep
+++ b/modules/sqlFirewallRules.bicep
@@ -1,0 +1,16 @@
+param sqlServerName string
+param startIp string = '186.182.86.0'
+param endIp string = '186.182.86.255'
+
+resource sqlServer 'Microsoft.Sql/servers@2022-02-01' existing = {
+  name: sqlServerName
+}
+
+resource sqlFirewallRule 'Microsoft.Sql/servers/firewallRules@2022-02-01-preview' = {
+  name: 'AllowCorpIpRange'
+  parent: sqlServer
+  properties: {
+    startIpAddress: startIp
+    endIpAddress: endIp
+  }
+}

--- a/modules/vnet.bicep
+++ b/modules/vnet.bicep
@@ -1,0 +1,34 @@
+param location string
+param vnetName string = 'vnet-dev'
+param addressPrefix string = '10.0.0.0/16'
+param subnetName string = 'snet-private-endpoints'
+param subnetPrefix string = '10.0.1.0/24'
+
+resource vnet 'Microsoft.Network/virtualNetworks@2023-05-01' = {
+  name: vnetName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        addressPrefix
+      ]
+    }
+    subnets:[
+      {
+        name: subnetName
+        properties:{
+          addressPrefix: subnetPrefix
+          privateEndpointNetworkPolicies: 'Disabled'
+          delegations: [
+            {
+            name: 'delegation-sql'
+            propierties: {
+              serviceName: 'Microsoft.Sql/servers'
+            }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### 🔐 Summary

This PR introduces the following improvements to the infrastructure project:

- ✅ **Firewall Rules for Azure SQL**: restrict access to a defined IP range.
- ✅ **Firewall Rules for Key Vault**: block public access and allow only trusted IPs.
- ✅ **Modularized design**: each security rule is implemented as a dedicated Bicep module.
- 🛡️ **Optional Private Endpoint for SQL Server**:
  - Includes conditional deployment via `enablePrivateEndpoint` parameter.
  - Supports integration with delegated subnet from a dedicated VNet module.
- 🧱 **VNet Module**: creates private virtual network and subnet ready for Private Endpoint connections.

This work completes the **Network Security Layer** and prepares the foundation for **Week 4 – Security & Permissions** of the project.

---